### PR TITLE
Fix path callback Swift name

### DIFF
--- a/Sources/OpenRenderBox/Path/ORBPathCallbacks.swift
+++ b/Sources/OpenRenderBox/Path/ORBPathCallbacks.swift
@@ -5,35 +5,39 @@
 #if !OPENRENDERBOX_CF_CGTYPES
 public import OpenCoreGraphicsShims
 
+// MARK: - ORBPath.CallbacksFlags
+
+extension ORBPath {
+    /// Flags for path callbacks
+    public struct CallbacksFlags {
+        public var unknown0: UInt8
+        public var unknown1: UInt8
+        public var isExtended: Bool
+        public var padding: (UInt8, UInt8, UInt8, UInt8, UInt8)
+
+        public init() {
+            self.unknown0 = 0
+            self.unknown1 = 0
+            self.isExtended = false
+            self.padding = (0, 0, 0, 0, 0)
+        }
+
+        public init(unknown0: UInt8, unknown1: UInt8, isExtended: Bool, padding: (UInt8, UInt8, UInt8, UInt8, UInt8)) {
+            self.unknown0 = unknown0
+            self.unknown1 = unknown1
+            self.isExtended = isExtended
+            self.padding = padding
+        }
+    }
+}
+
 // MARK: - ORBPath.Callbacks
 
 extension ORBPath {
     /// Callbacks structure for path operations
     /// This allows different path storage types (CGPath, custom storage, etc.) to provide their own implementations
     public struct Callbacks {
-        /// Flags for path callbacks
-        public struct Flags {
-            public var unknown0: UInt8
-            public var unknown1: UInt8
-            public var isExtended: Bool
-            public var padding: (UInt8, UInt8, UInt8, UInt8, UInt8)
-
-            public init() {
-                self.unknown0 = 0
-                self.unknown1 = 0
-                self.isExtended = false
-                self.padding = (0, 0, 0, 0, 0)
-            }
-
-            public init(unknown0: UInt8, unknown1: UInt8, isExtended: Bool, padding: (UInt8, UInt8, UInt8, UInt8, UInt8)) {
-                self.unknown0 = unknown0
-                self.unknown1 = unknown1
-                self.isExtended = isExtended
-                self.padding = padding
-            }
-        }
-
-        public var flags: ORBPath.Callbacks.Flags
+        public var flags: ORBPath.CallbacksFlags
         public var retain: ((UnsafeRawPointer) -> UnsafeRawPointer)?
         public var release: ((UnsafeRawPointer) -> Void)?
         public var apply: ((UnsafeRawPointer, UnsafeMutableRawPointer, ORBPathApplyCallback?) -> Bool)?
@@ -46,7 +50,7 @@ extension ORBPath {
         public var next: ((UnsafeRawPointer) -> UnsafePointer<ORBPath.Callbacks>?)?
         
         public init() {
-            self.flags = ORBPath.Callbacks.Flags()
+            self.flags = ORBPath.CallbacksFlags()
             self.retain = nil
             self.release = nil
             self.apply = nil
@@ -60,7 +64,7 @@ extension ORBPath {
         }
         
         public init(
-            flags: ORBPath.Callbacks.Flags,
+            flags: ORBPath.CallbacksFlags,
             retain: ((UnsafeRawPointer) -> UnsafeRawPointer)?,
             release: ((UnsafeRawPointer) -> Void)?,
             apply: ((UnsafeRawPointer, UnsafeMutableRawPointer, ORBPathApplyCallback?) -> Bool)?,
@@ -101,7 +105,7 @@ extension ORBPath.Callbacks {
 extension ORBPath {
     /// Extended callbacks structure with additional extended callbacks argument
     public struct CallbacksExtended {
-        public var flags: ORBPath.Callbacks.Flags
+        public var flags: ORBPath.CallbacksFlags
         public var retain: ((UnsafeRawPointer) -> UnsafeRawPointer)?
         public var release: ((UnsafeRawPointer) -> Void)?
         public var apply: ((UnsafeRawPointer, UnsafeMutableRawPointer, ORBPathApplyCallback?, UnsafePointer<ORBPath.CallbacksExtended>) -> Bool)?
@@ -114,7 +118,7 @@ extension ORBPath {
         public var next: ((UnsafeRawPointer, UnsafePointer<ORBPath.CallbacksExtended>) -> UnsafePointer<ORBPath.CallbacksExtended>?)?
         
         public init() {
-            self.flags = ORBPath.Callbacks.Flags()
+            self.flags = ORBPath.CallbacksFlags()
             self.retain = nil
             self.release = nil
             self.apply = nil
@@ -128,7 +132,7 @@ extension ORBPath {
         }
 
         public init(
-            flags: ORBPath.Callbacks.Flags,
+            flags: ORBPath.CallbacksFlags,
             retain: ((UnsafeRawPointer) -> UnsafeRawPointer)?,
             release: ((UnsafeRawPointer) -> Void)?,
             apply: ((UnsafeRawPointer, UnsafeMutableRawPointer, ORBPathApplyCallback?, UnsafePointer<ORBPath.CallbacksExtended>) -> Bool)?,

--- a/Sources/OpenRenderBoxCxx/include/OpenRenderBox/ORBPathCallbacks.h
+++ b/Sources/OpenRenderBoxCxx/include/OpenRenderBox/ORBPathCallbacks.h
@@ -21,7 +21,7 @@ ORB_ASSUME_NONNULL_BEGIN
 ORB_EXTERN_C_BEGIN
 
 /// Flags for path callbacks
-typedef struct ORB_SWIFT_NAME(ORBPath.Callbacks.Flags) ORBPathCallbacksFlags {
+typedef struct ORB_SWIFT_NAME(ORBPath.CallbacksFlags) ORBPathCallbacksFlags {
     uint8_t unknown0;
     uint8_t unknown1;
     bool isExtended;


### PR DESCRIPTION
## Summary

Fix the Swift importer name for path callback flags by using the valid nested type name `ORBPath.CallbacksFlags` instead of the unsupported `ORBPath.Callbacks.Flags` spelling.

This keeps the callback flag type named for Swift users instead of leaving it as a plain C import, and updates the non-CoreGraphics fallback Swift declarations to match the imported API shape.

## Root Cause

The Swift importer accepts the `ORBPath.Callbacks` record mapping, but rejects the deeper `ORBPath.Callbacks.Flags` record name and reports an invalid base identifier warning.

## Validation

- Typechecked `OpenRenderBox.h` through `swiftc -typecheck -import-objc-header` and verified `ORBPath.CallbacksFlags` imports without the warning.
- Built OpenSwiftUI with local dependencies enabled:
  `OPENSWIFTUI_USE_LOCAL_DEPS=1 OPENRENDERBOX_USE_LOCAL_DEPS=1 OPENATTRIBUTEGRAPH_USE_LOCAL_DEPS=1 swift build --target OpenSwiftUI`
- Confirmed the local-dependency build log has no `Callbacks.Flags` or invalid `swift_name` warning matches.